### PR TITLE
Add ort-server repository

### DIFF
--- a/otterdog/eclipse-apoapsis.jsonnet
+++ b/otterdog/eclipse-apoapsis.jsonnet
@@ -7,4 +7,14 @@ orgs.newOrg('eclipse-apoapsis') {
     name: "Apoapsis project",
     web_commit_signoff_required: false,
   },
+  _repositories+:: [
+    orgs.newRepo('ort-server') {
+      # Only set values that differ from the defaults, see:
+      # https://github.com/EclipseFdn/otterdog-defaults/blob/main/otterdog-defaults.libsonnet
+      has_wiki: false,
+      auto_init: false,
+      allow_squash_merge: false,
+      allow_auto_merge: true,
+    },
+  ],
 }


### PR DESCRIPTION
Add the repository for the ort-server with minimal configuration for the initial contribution. All other configuration like branch protection rules will be added after the import.