### PR TITLE
Do not inherit default required status checks for ort-server

### DIFF
--- a/otterdog/eclipse-apoapsis.jsonnet
+++ b/otterdog/eclipse-apoapsis.jsonnet
@@ -19,7 +19,7 @@ orgs.newOrg('eclipse-apoapsis') {
           dismisses_stale_reviews: true,
           is_admin_enforced: true,
           required_approving_review_count: 1,
-          required_status_checks+: [
+          required_status_checks: [
             "build",
             "commit-lint",
             "detekt-issues",


### PR DESCRIPTION
Do not inherit from the default required status checks in the ort-server repository. This effectively removes the `eclipsefdn/eca` check from the list of required checks. The reason is that this check is currently not triggered by the `merge_group` event and therefore the checks in the merge queue time out which makes it impossible to merge any pull requests. For details see [1].

The check can be made required again once [2] was implemented.

[1]: https://github.com/eclipse-apoapsis/.eclipsefdn/issues/3#issuecomment-2007877538
[2]: https://gitlab.eclipse.org/eclipsefdn/it/api/git-eca-rest-api/-/issues/161