### PR TITLE
ort-server: Add more required status checks for main branch

### DIFF
--- a/otterdog/eclipse-apoapsis.jsonnet
+++ b/otterdog/eclipse-apoapsis.jsonnet
@@ -21,9 +21,11 @@ orgs.newOrg('eclipse-apoapsis') {
           required_approving_review_count: 1,
           required_status_checks: [
             "build",
+            "build-ui",
             "commit-lint",
             "detekt-issues",
             "integration-test",
+            "renovate-validation",
             "reuse-tool",
             "test",
             "wrapper-validation",


### PR DESCRIPTION
Add "build-ui" and "renovate-validation" as required status checks to the branch protection rule of the main branch.