### PR TITLE
feat: Add `setup-osc` repository

### DIFF
--- a/otterdog/eclipse-apoapsis.jsonnet
+++ b/otterdog/eclipse-apoapsis.jsonnet
@@ -164,6 +164,24 @@ orgs.newOrg('technology.apoapsis', 'eclipse-apoapsis') {
           requires_linear_history: true,
         },
       ],
+    },
+    orgs.newRepo('setup-osc') {
+      allow_auto_merge: true,
+      allow_squash_merge: false,
+      description: "A GitHub action to set up the ORT Server Client CLI (osc).",
+      has_discussions: false,
+      has_wiki: false,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          dismisses_stale_reviews: true,
+          is_admin_enforced: true,
+          required_approving_review_count: 1,
+          required_status_checks+: [
+            "renovate-validation"
+          ],
+          requires_linear_history: true,
+        },
+      ]
     }
   ],
 } + {


### PR DESCRIPTION
The purpose of this repository is to provide a public GitHub action to set up the ORT Server Client CLI (osc).