### PR TITLE
feat: Remove Kubernetes JobMonitor build as required check.

### DIFF
--- a/otterdog/eclipse-apoapsis.jsonnet
+++ b/otterdog/eclipse-apoapsis.jsonnet
@@ -123,7 +123,6 @@ orgs.newOrg('technology.apoapsis', 'eclipse-apoapsis') {
               "test",
               "website-test",
               "Build core Docker Image",
-              "Build kubernetes-jobmonitor Docker Image",
               "Build orchestrator Docker Image",
               "Build ui Docker Image",
               "Build advisor-worker Docker Image",


### PR DESCRIPTION
After a refactoring, Kubernetes JobMonitor is no longer a stand-alone component, and this build has been dropped.