### PR TITLE
feat: Rename setup-osc repository to actions

### DIFF
--- a/otterdog/eclipse-apoapsis.jsonnet
+++ b/otterdog/eclipse-apoapsis.jsonnet
@@ -26,6 +26,25 @@ orgs.newOrg('technology.apoapsis', 'eclipse-apoapsis') {
     },
   ],
   _repositories+:: [
+    orgs.newRepo('actions') {
+      aliases: ['setup-osc'],
+      allow_auto_merge: true,
+      allow_squash_merge: false,
+      description: "A collection of GitHub actions for the Eclipse Apoapsis project.",
+      has_discussions: false,
+      has_wiki: false,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          dismisses_stale_reviews: true,
+          is_admin_enforced: true,
+          required_approving_review_count: 1,
+          required_status_checks+: [
+            "renovate-validation"
+          ],
+          requires_linear_history: true,
+        },
+      ]
+    },
     orgs.newRepo('guidance') {
       allow_auto_merge: true,
       allow_squash_merge: false,
@@ -163,24 +182,6 @@ orgs.newOrg('technology.apoapsis', 'eclipse-apoapsis') {
           requires_linear_history: true,
         },
       ],
-    },
-    orgs.newRepo('setup-osc') {
-      allow_auto_merge: true,
-      allow_squash_merge: false,
-      description: "A GitHub action to set up the ORT Server Client CLI (osc).",
-      has_discussions: false,
-      has_wiki: false,
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          dismisses_stale_reviews: true,
-          is_admin_enforced: true,
-          required_approving_review_count: 1,
-          required_status_checks+: [
-            "renovate-validation"
-          ],
-          requires_linear_history: true,
-        },
-      ]
     }
   ],
 } + {


### PR DESCRIPTION
Setting it up like this has the advantage that multiple actions can reside within a single repository.
E.g. Gradle is doing it like this: https://github.com/gradle/actions

The `actions` repository will have subdirectories for the specific actions.

The usage will change from:
```
uses: eclipse-apoapsis/setup-osc@main
```
to
```
uses: eclipse-apoapsis/actions/setup-osc@main
```

Downside:
Once we start doing releases for the GH actions, every action will use the same version.